### PR TITLE
Update repo path for gatsby new command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Medusa is an open-source headless commerce engine that enables developers to cre
 
 1. **Install the storefront**
    ```shell
-   gatsby new medusa-contentful-storefront https://github.com/medusajs/medusa-contentful-storefront/edit/master/README.md
+   gatsby new medusa-contentful-storefront https://github.com/medusajs/medusa-contentful-storefront
    ```
 2. **Setup your environment variables**
 


### PR DESCRIPTION
The previous command will not be able to successfully run as it is pointing to a README file. Simple change, but people new to gatsby might stumble. 